### PR TITLE
File grouping and management for Minecraft instances

### DIFF
--- a/source/modules/Packsly3.Cli/Program.cs
+++ b/source/modules/Packsly3.Cli/Program.cs
@@ -43,11 +43,15 @@ namespace Packsly3.Cli {
             Console.WriteLine($" > Current handler: {Launcher.Current}");
             Console.WriteLine();
 
+            /*
             IMinecraftInstance instance = MinecraftInstanceFactory.CreateFromModpack(
                 new FileInfo(
                     Path.Combine(Directory.GetCurrentDirectory(), "modpack.json")
                 )
             );
+            */
+
+            IMinecraftInstance instnance = Launcher.GetInstance("modpack");
 
             /*
             Lifecycle.Dispatcher.Publish(Launcher.GetInstance("modpack") ,Lifecycle.PreLaunch);

--- a/source/modules/Packsly3.Cli/Program.cs
+++ b/source/modules/Packsly3.Cli/Program.cs
@@ -51,11 +51,7 @@ namespace Packsly3.Cli {
             );
             */
 
-            IMinecraftInstance instnance = Launcher.GetInstance("modpack");
-
-            /*
             Lifecycle.Dispatcher.Publish(Launcher.GetInstance("modpack") ,Lifecycle.PreLaunch);
-            */
 
             Console.ReadKey();
 

--- a/source/modules/Packsly3.Core/Common/Json/LowercaseContractResolver.cs
+++ b/source/modules/Packsly3.Core/Common/Json/LowercaseContractResolver.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json.Serialization;
+
+namespace Packsly3.Core.Common.Json {
+
+    internal class LowercaseContractResolver : DefaultContractResolver {
+
+        protected override string ResolvePropertyName(string propertyName) {
+            return propertyName.ToLower();
+        }
+
+    }
+
+}

--- a/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
+++ b/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Runtime.Remoting.Messaging;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -39,8 +34,6 @@ namespace Packsly3.Core.Common.Json {
 
             return  Activator.CreateInstance(objectType, resolvedPath);
         }
-
-
 
     }
 

--- a/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
+++ b/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Remoting.Messaging;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Packsly3.Core.Common.Json {
+
+    internal class RelativePathConverter : JsonConverter {
+
+        public string Root { get; set; } = Directory.GetCurrentDirectory();
+
+        public override bool CanConvert(Type objectType)
+            => objectType.IsSubclassOf(typeof(FileSystemInfo)) || objectType == typeof(FileSystemInfo);
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) {
+            string path = ((FileSystemInfo)value).FullName;
+
+            JValue jValue = new JValue(
+                path.StartsWith(Root)
+                    ? "." + path.Remove(0, Root.Length)
+                    : path);
+
+            jValue.WriteTo(writer);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) {
+            if (objectType != typeof(FileInfo) && objectType != typeof(DirectoryInfo))
+                throw new NotSupportedException( $"{GetType().Name} does not support deserialization of '{objectType}' type.");
+
+            string path = JToken.Load(reader).Value<string>();
+            string resolvedPath = path.StartsWith(@".\")
+                ? Path.Combine(Root, path.Remove(0, 2))
+                : path;
+
+            return  Activator.CreateInstance(objectType, resolvedPath);
+        }
+
+
+
+    }
+
+}

--- a/source/modules/Packsly3.Core/FileSystem/JsonFile.cs
+++ b/source/modules/Packsly3.Core/FileSystem/JsonFile.cs
@@ -8,17 +8,16 @@ namespace Packsly3.Core.FileSystem {
     [JsonObject(MemberSerialization.OptIn)]
     public abstract class JsonFile : FileBase {
 
-        private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings {
+        private static readonly JsonSerializerSettings DefaultSerializerSettings = new JsonSerializerSettings {
             ContractResolver = new LowercaseContractResolver(),
-            ObjectCreationHandling = ObjectCreationHandling.Replace,
-            Converters = {
-                new RelativePathConverter {
-                    Root = Launcher.Launcher.Workspace.FullName
-                }
-            }
+            ObjectCreationHandling = ObjectCreationHandling.Replace
         };
 
         protected JsonFile(string path) : base(path) {
+        }
+
+        protected virtual JsonSerializerSettings GetSerializerSettings() {
+            return DefaultSerializerSettings;
         }
 
         public override void Load() {
@@ -26,7 +25,7 @@ namespace Packsly3.Core.FileSystem {
                 return;
 
             using (StreamReader reader = ThisFile.OpenText())
-                JsonConvert.PopulateObject(reader.ReadToEnd(), this, SerializerSettings);
+                JsonConvert.PopulateObject(reader.ReadToEnd(), this, GetSerializerSettings());
         }
 
         public override void Save() {
@@ -35,7 +34,7 @@ namespace Packsly3.Core.FileSystem {
             }
 
             using (StreamWriter writer = ThisFile.CreateText())
-                writer.Write(JsonConvert.SerializeObject(this, Formatting.Indented, SerializerSettings));
+                writer.Write(JsonConvert.SerializeObject(this, Formatting.Indented, GetSerializerSettings()));
         }
 
     }

--- a/source/modules/Packsly3.Core/FileSystem/JsonFile.cs
+++ b/source/modules/Packsly3.Core/FileSystem/JsonFile.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
 using Newtonsoft.Json;
+using Packsly3.Core.Common;
+using Packsly3.Core.Common.Json;
 
 namespace Packsly3.Core.FileSystem {
 
@@ -7,7 +9,13 @@ namespace Packsly3.Core.FileSystem {
     public abstract class JsonFile : FileBase {
 
         private static readonly JsonSerializerSettings SerializerSettings = new JsonSerializerSettings {
-            ObjectCreationHandling = ObjectCreationHandling.Replace
+            ContractResolver = new LowercaseContractResolver(),
+            ObjectCreationHandling = ObjectCreationHandling.Replace,
+            Converters = {
+                new RelativePathConverter {
+                    Root = Launcher.Launcher.Workspace.FullName
+                }
+            }
         };
 
         protected JsonFile(string path) : base(path) {
@@ -27,7 +35,7 @@ namespace Packsly3.Core.FileSystem {
             }
 
             using (StreamWriter writer = ThisFile.CreateText())
-                writer.Write(JsonConvert.SerializeObject(this, Formatting.Indented));
+                writer.Write(JsonConvert.SerializeObject(this, Formatting.Indented, SerializerSettings));
         }
 
     }

--- a/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
+++ b/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
@@ -14,6 +14,8 @@ namespace Packsly3.Core.FileSystem {
 
     public partial class PackslyInstanceFile : JsonFile {
 
+        private readonly JsonSerializerSettings _serializerSettings;
+
         [JsonProperty("adapters")]
         internal AdaptersConfig Adapters { private set; get; } = new AdaptersConfig();
 
@@ -21,12 +23,24 @@ namespace Packsly3.Core.FileSystem {
         internal Dictionary<FileManager.GroupType, List<FileInfo>> ManagedFiles { private set; get; } = new Dictionary<FileManager.GroupType, List<FileInfo>>();
 
         public PackslyInstanceFile(string path) : base(Path.Combine(path, "instnace.packsly")) {
+            _serializerSettings = new JsonSerializerSettings {
+                ContractResolver = new LowercaseContractResolver(),
+                ObjectCreationHandling = ObjectCreationHandling.Replace,
+                Converters = {
+                    new RelativePathConverter {
+                        Root = DirectoryPath
+                    }
+                }
+            };
+
             Load();
         }
 
-        public sealed override void Load() {
-            base.Load();
-        }
+        protected override JsonSerializerSettings GetSerializerSettings()
+            => _serializerSettings;
+
+        public sealed override void Load()
+            => base.Load();
 
     }
 

--- a/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
+++ b/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Packsly3.Core.Launcher.Adapter;
+using Packsly3.Core.Launcher.Instance;
 
 namespace Packsly3.Core.FileSystem {
 
@@ -14,6 +15,9 @@ namespace Packsly3.Core.FileSystem {
 
         [JsonProperty("adapters")]
         internal AdaptersConfig Adapters { private set; get; } = new AdaptersConfig();
+
+        [JsonProperty("files")]
+        internal Dictionary<FileManager.GroupType, List<FileInfo>> ManagedFiles { private set; get; } = new Dictionary<FileManager.GroupType, List<FileInfo>>();
 
         public PackslyInstanceFile(string path) : base(Path.Combine(path, "instnace.packsly")) {
             Load();

--- a/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
+++ b/source/modules/Packsly3.Core/FileSystem/PackslyInstanceFile.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Packsly3.Core.Common.Json;
 using Packsly3.Core.Launcher.Adapter;
 using Packsly3.Core.Launcher.Instance;
 

--- a/source/modules/Packsly3.Core/Launcher/Instance/FileManager.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/FileManager.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Packsly3.Core.Modpack;
+
+namespace Packsly3.Core.Launcher.Instance {
+
+    public class FileManager : IDisposable {
+
+        public readonly ReadOnlyDictionary<GroupType, List<FileInfo>> FileMap;
+
+        private readonly WebClient _client = new WebClient();
+        private readonly IMinecraftInstance _instance;
+
+        public bool IsDirty { private set; get; }
+
+        public FileManager(IMinecraftInstance instance) {
+            instance.PackslyConfig.Load();
+            FileMap = new ReadOnlyDictionary<GroupType, List<FileInfo>>(instance.PackslyConfig.ManagedFiles);
+            _instance = instance;
+        }
+
+        public void Add(FileInfo file, GroupType group) {
+            if (!file.Exists) {
+                throw new FileNotFoundException($"File with path '{file.FullName}' cound not be added to file manager because it does not exist");
+            }
+
+            if (FileMap.ContainsKey(group)) {
+                if (FileMap[group].Any(f => f.FullName.GetHashCode() == file.FullName.GetHashCode())) {
+                    throw new DuplicateNameException($"Group '{group}' allready contains file with path '{file.FullName}'");
+                }
+            } else {
+                _instance.PackslyConfig.ManagedFiles.Add(group, new List<FileInfo>());
+            }
+
+            _instance.PackslyConfig.ManagedFiles[group].Add(file);
+
+            IsDirty = true;
+        }
+
+        public void Add(string path, GroupType group)
+            => Add(new FileInfo(path), group);
+
+        public void Download(string url, string destination, GroupType group) {
+            FileInfo destinationFile = new FileInfo(destination);
+
+            if (destinationFile.Directory != null && !destinationFile.Directory.Exists) {
+                destinationFile.Directory.Create();
+            }
+
+            _client.DownloadFile(url, destination);
+            Add(destinationFile, group);
+        }
+
+        public void Download(RemoteResource resource, GroupType group) =>
+            Download(resource.Url.ToString(), _instance.EnvironmentVariables.Format(Path.Combine(resource.FilePath, resource.FileName)), group);
+
+        public void Remove(FileInfo file, GroupType group) {
+            if (!FileMap.ContainsKey(group)) {
+                return;
+            }
+
+            List<FileInfo> fileGroup = FileMap[group];
+            FileInfo toRemove = file;
+
+            if (!fileGroup.Contains(file)) {
+                toRemove = fileGroup.FirstOrDefault(f => f.FullName.GetHashCode() == file.FullName.GetHashCode());
+            }
+
+            if (toRemove == null) {
+                throw new FileNotFoundException($"Group '{group}' does not contain file with path '{file.FullName}'");
+            }
+
+            fileGroup.Remove(toRemove);
+
+            if (fileGroup.Count == 0) {
+                _instance.PackslyConfig.ManagedFiles.Remove(group);
+            }
+
+            IsDirty = true;
+        }
+
+        public void Remove(string path, GroupType group)
+            => Remove(new FileInfo(path), group);
+
+        public FileInfo[] GetMissingFiles(GroupType group) {
+            if (!FileMap.ContainsKey(group)) {
+                return new FileInfo[0];
+            }
+
+            List<FileInfo> fileGroup = FileMap[group];
+            return fileGroup.Where(f => !f.Exists).ToArray();
+        }
+
+        public void Save() {
+            if (!IsDirty)
+                return;
+
+            _instance.PackslyConfig.Save();
+            IsDirty = false;
+        }
+
+        #region IDisposable
+
+        private bool _disposed;
+
+        protected virtual void Dispose(bool disposing) {
+            if (!_disposed) {
+                if (disposing) {
+                    _client.Dispose();
+                }
+            }
+
+            _disposed = true;
+        }
+
+        public void Dispose() {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+        public enum GroupType {
+            PackslyInternal,
+            Mod,
+            ModResource,
+            Miscellaneous
+        }
+
+    }
+
+}

--- a/source/modules/Packsly3.Core/Launcher/Instance/IMinecraftInstance.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/IMinecraftInstance.cs
@@ -10,12 +10,6 @@ namespace Packsly3.Core.Launcher.Instance {
 
         DirectoryInfo Location { get; }
 
-        EnvironmentVariables EnvironmentVariables { get; }
-
-        PackslyInstanceFile PackslyConfig { get; }
-
-        ModLoaderManager ModLoaderManager { get; }
-
         string Id { get; }
 
         string Name { set; get; }
@@ -23,6 +17,14 @@ namespace Packsly3.Core.Launcher.Instance {
         string MinecraftVersion { set; get; }
 
         Icon Icon { get; }
+
+        EnvironmentVariables EnvironmentVariables { get; }
+
+        PackslyInstanceFile PackslyConfig { get; }
+
+        ModLoaderManager ModLoaderManager { get; }
+
+        FileManager Files { get; }
 
         void Configure(string json);
 

--- a/source/modules/Packsly3.Core/Launcher/Instance/Lifecycle.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/Lifecycle.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Reflection;
 using Packsly3.Core.Launcher.Adapter;
-using Packsly3.Core.Modpack;
 
 namespace Packsly3.Core.Launcher.Instance {
 

--- a/source/modules/Packsly3.Core/Launcher/Instance/MinecraftInstanceFactory.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/MinecraftInstanceFactory.cs
@@ -43,33 +43,17 @@ namespace Packsly3.Core.Launcher.Instance {
             }
 
             // Download mods
-            using (WebClient client = new WebClient()) {
-                foreach (ModSource modSource in modpackDefinition.Mods) {
-                    DirectoryInfo envModPath =
-                        new DirectoryInfo(instance.EnvironmentVariables.Format(modSource.FilePath));
-                    Console.WriteLine($"Downloading mod '{modSource.FileName}' to '{envModPath.FullName}'...");
+            foreach (ModSource mod in modpackDefinition.Mods) {
+                Console.WriteLine($"Downloading mod '{mod.FileName}' to '{mod.FilePath}'...");
+                instance.Files.Download(mod, FileManager.GroupType.Mod);
 
-                    if (!envModPath.Exists) {
-                        envModPath.Create();
-                    }
-
-                    client.DownloadFile(modSource.Url, Path.Combine(envModPath.FullName, modSource.FileName));
-
-                    // Download mod resources
-                    foreach (RemoteResource resource in modSource.Resources) {
-                        DirectoryInfo envResPath =
-                            new DirectoryInfo(instance.EnvironmentVariables.Format(resource.FilePath));
-                        Console.WriteLine(
-                            $" > Downloading resource '{resource.FileName}' to '{envResPath.FullName}'...");
-
-                        if (!envResPath.Exists) {
-                            envResPath.Create();
-                        }
-
-                        client.DownloadFile(resource.Url, Path.Combine(envResPath.FullName, resource.FileName));
-                    }
+                // Download mod resources
+                foreach (RemoteResource resource in mod.Resources) {
+                    Console.WriteLine($" > Downloading resource '{resource.FileName}' to '{resource.FilePath}'...");
+                    instance.Files.Download(resource, FileManager.GroupType.ModResource);
                 }
             }
+            instance.Files.Save();
 
             Lifecycle.Dispatcher.Publish(instance, Lifecycle.PostInstallation);
 

--- a/source/modules/Packsly3.Core/Packsly3.Core.csproj
+++ b/source/modules/Packsly3.Core/Packsly3.Core.csproj
@@ -47,7 +47,8 @@
     <Compile Include="Launcher\Adapter\AdapterHandler.cs" />
     <Compile Include="Launcher\Adapter\IAdapter.cs" />
     <Compile Include="Launcher\Adapter\Impl\RevisionUpdateAdapter.cs" />
-    <Compile Include="Launcher\Instance\LifecycleDispatcher.cs" />
+    <Compile Include="Launcher\Instance\FileManager.cs" />
+    <Compile Include="Launcher\Instance\Lifecycle.cs" />
     <Compile Include="Launcher\Instance\EnvironmentVariables.cs" />
     <Compile Include="Launcher\Instance\Icon.cs" />
     <Compile Include="Modpack\ModSource.cs" />

--- a/source/modules/Packsly3.Core/Packsly3.Core.csproj
+++ b/source/modules/Packsly3.Core/Packsly3.Core.csproj
@@ -43,6 +43,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\Json\LowercaseContractResolver.cs" />
+    <Compile Include="Common\Json\RelativePathConverter.cs" />
     <Compile Include="FileSystem\PackslyInstanceFile.cs" />
     <Compile Include="Launcher\Adapter\AdapterHandler.cs" />
     <Compile Include="Launcher\Adapter\IAdapter.cs" />

--- a/source/modules/Packsly3.MultiMC/Launcher/MmcMinecraftInstance.cs
+++ b/source/modules/Packsly3.MultiMC/Launcher/MmcMinecraftInstance.cs
@@ -31,21 +31,24 @@ namespace Packsly3.MultiMC.Launcher {
             => Location.Name;
 
         public string Name {
-            get => Config.GetField<string>();
-            set => Config.SetField(value);
+            get => MmcConfig.GetField<string>();
+            set => MmcConfig.SetField(value);
         }
 
         public string MinecraftVersion {
-            get => Config.GetField<string>();
-            set => Config.SetField(value);
+            get => MmcConfig.GetField<string>();
+            set => MmcConfig.SetField(value);
         }
 
         public Icon Icon { get; }
 
         public ModLoaderManager ModLoaderManager { get; }
 
-        internal MmcConfigFile Config { get; }
-        internal MmcPackFile Pack { get; }
+        public FileManager Files { get; }
+
+        internal MmcConfigFile MmcConfig { get; }
+
+        internal MmcPackFile PackFile { get; }
 
         public MmcMinecraftInstance(DirectoryInfo location) {
             Location = location;
@@ -58,23 +61,25 @@ namespace Packsly3.MultiMC.Launcher {
 
             PackslyConfig = new PackslyInstanceFile(Path.Combine(Location.FullName));
 
-            Config = new MmcConfigFile(Location.FullName);
-            if (!Config.Exists) {
-                Config.WithDefaults();
+            MmcConfig = new MmcConfigFile(Location.FullName);
+            if (!MmcConfig.Exists) {
+                MmcConfig.WithDefaults();
             }
 
-            Pack = new MmcPackFile(Location.FullName);
-            Pack.Load();
+            PackFile = new MmcPackFile(Location.FullName);
+            PackFile.Load();
 
-            Icon = new Icon(Path.Combine(Core.Launcher.Launcher.Workspace.FullName, "icons"), Config.IconName);
+            Icon = new Icon(Path.Combine(Core.Launcher.Launcher.Workspace.FullName, "icons"), MmcConfig.IconName);
             Icon.IconChanged += (sender, args)
-                => Config.IconName = (sender as Icon)?.Source;
+                => MmcConfig.IconName = (sender as Icon)?.Source;
 
             ModLoaderManager = new ModLoaderManager(this);
+
+            Files = new FileManager(this);
         }
 
         public void Configure(string json) {
-            JsonConvert.PopulateObject(json, Config);
+            JsonConvert.PopulateObject(json, MmcConfig);
         }
 
         public void Save() {
@@ -82,7 +87,7 @@ namespace Packsly3.MultiMC.Launcher {
                 Location.Create();
             }
 
-            Config.Save();
+            MmcConfig.Save();
         }
 
         public void Delete() {

--- a/source/modules/Packsly3.MultiMC/Launcher/Modloader/MmcModLoaderHandler.cs
+++ b/source/modules/Packsly3.MultiMC/Launcher/Modloader/MmcModLoaderHandler.cs
@@ -35,7 +35,7 @@ namespace Packsly3.MultiMC.Launcher.Modloader {
             => ModLoadersMap.Keys.Contains(modLoader);
 
         public override void DetectModLoaders(MmcMinecraftInstance instance, List<ModLoaderInfo> modLoaders) {
-            if (!instance.Pack.Exists)
+            if (!instance.PackFile.Exists)
                 return;
 
             string[] ignored = {
@@ -44,7 +44,7 @@ namespace Packsly3.MultiMC.Launcher.Modloader {
             };
 
             IEnumerable<MmcPackFile.Component> compatibleComponents =
-                instance.Pack.Components.Where(c => !ignored.Contains(c.Uid.ToLower()));
+                instance.PackFile.Components.Where(c => !ignored.Contains(c.Uid.ToLower()));
 
             modLoaders.AddRange(
                 compatibleComponents.Select(component =>
@@ -53,7 +53,7 @@ namespace Packsly3.MultiMC.Launcher.Modloader {
         }
 
         public override void Install(MmcMinecraftInstance instance, string modLoader, string version) {
-            MmcPackFile pck = instance.Pack;
+            MmcPackFile pck = instance.PackFile;
 
             if (pck.Exists) {
                 pck.Load();
@@ -84,7 +84,7 @@ namespace Packsly3.MultiMC.Launcher.Modloader {
                 pck.Save();
             }
 
-            MmcConfigFile cfg = instance.Config;
+            MmcConfigFile cfg = instance.MmcConfig;
             string mlConfigKey = ModLoadersMap[modLoader].Value;
 
             cfg.Load();
@@ -93,17 +93,17 @@ namespace Packsly3.MultiMC.Launcher.Modloader {
         }
 
         public override void Uninstall(MmcMinecraftInstance instance, string modLoader) {
-            MmcPackFile pck = instance.Pack;
+            MmcPackFile pck = instance.PackFile;
 
             if (pck.Exists) {
                 pck.Load();
 
                 string mlUid = ModLoadersMap[modLoader].Key;
-                pck.Components.Remove(instance.Pack.Components.FirstOrDefault(c => c.Uid == mlUid));
+                pck.Components.Remove(instance.PackFile.Components.FirstOrDefault(c => c.Uid == mlUid));
                 pck.Save();
             }
 
-            MmcConfigFile cfg = instance.Config;
+            MmcConfigFile cfg = instance.MmcConfig;
             string mlConfigKey = ModLoadersMap[modLoader].Value;
 
             cfg.Load();


### PR DESCRIPTION
### Summary
In order to fix problem introduced by allowing usage arbitrary paths for mod resources along with how the revision based updating schema is supposed to work, minecraft instances can now have managed files. The path to these managed files is stored in packsly.instance file under a group name. These files are used to delete resources from mods removed from the modpack.

### The problem
When modpack is updated, it is easy to delete mods that were removed in the update by comparing list of files in the instance mods folder with list of mods in the modpack. However this is not the case with mod resources which can be anywhere. Since revision update schema is based around of the idea of editing single modpack file, there is no way to list all mod resources without storing every single one of modpack file revisions.

### Conclusion
The problem with leaving behind mod resources after the mod was removed from the modpack was fixed by checking mod-resource group in instance file manager for any files that are not currently specified in the modpack definition.