### PR TITLE
Configuration file implementation (Closes #4)

### DIFF
--- a/resources/packsly-config-example.json
+++ b/resources/packsly-config-example.json
@@ -1,0 +1,4 @@
+{
+  "workspace": "D:\\Games\\MultiMC",
+  "modpack": ".\\modpack.json"
+}

--- a/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
+++ b/source/modules/Packsly3.Core/Common/Json/RelativePathConverter.cs
@@ -28,11 +28,16 @@ namespace Packsly3.Core.Common.Json {
                 throw new NotSupportedException( $"{GetType().Name} does not support deserialization of '{objectType}' type.");
 
             string path = JToken.Load(reader).Value<string>();
+
+            if (string.IsNullOrEmpty(path)) {
+                return null;
+            }
+
             string resolvedPath = path.StartsWith(@".\")
                 ? Path.Combine(Root, path.Remove(0, 2))
                 : path;
 
-            return  Activator.CreateInstance(objectType, resolvedPath);
+            return Activator.CreateInstance(objectType, resolvedPath);
         }
 
     }

--- a/source/modules/Packsly3.Core/FileSystem/PackslyConfig.cs
+++ b/source/modules/Packsly3.Core/FileSystem/PackslyConfig.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Packsly3.Core.Common.Json;
+using Packsly3.Core.Modpack;
+
+namespace Packsly3.Core.FileSystem {
+
+    public class PackslyConfig : JsonFile {
+
+        public static readonly PackslyConfig Instnace = new PackslyConfig(
+            Path.GetDirectoryName(Assembly.GetEntryAssembly().Location)
+        );
+
+        [JsonProperty("workspace")]
+        [JsonConverter(typeof(RelativePathConverter))]
+        public DirectoryInfo Workspace { private set; get; }
+
+        [JsonProperty("modpack")]
+        public string DefaultModpackSource { private set; get; }
+
+        private PackslyConfig(string path) : base(Path.Combine(path, "packsly.json")) {
+            if (!Exists) {
+                Save();
+            }
+
+            Load();
+        }
+
+        public sealed override void Save()
+            => base.Save();
+
+        public sealed override void Load()
+            => base.Load();
+
+    }
+
+}

--- a/source/modules/Packsly3.Core/Launcher/Launcher.cs
+++ b/source/modules/Packsly3.Core/Launcher/Launcher.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Management.Instrumentation;
+using System.Reflection;
 using Packsly3.Core.Common;
 using Packsly3.Core.Launcher.Instance;
 
@@ -12,7 +13,7 @@ namespace Packsly3.Core.Launcher {
         private static readonly ILauncherEnvironment[] Enviroments =
             RegisterAttribute.GetOccurrencesFor<ILauncherEnvironment>();
 
-        private static readonly DirectoryInfo Root = new DirectoryInfo(Directory.GetCurrentDirectory());
+        private static readonly DirectoryInfo Root = new DirectoryInfo(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) ?? throw new InvalidOperationException());
 
         public static DirectoryInfo Workspace { get; set; } = Root;
 
@@ -28,7 +29,7 @@ namespace Packsly3.Core.Launcher {
 
             ILauncherEnvironment env = Enviroments.FirstOrDefault(e => e.IsCompatible(Workspace));
             if (env == null) {
-                throw new Exception($"No compatible enviromnet found in workspace '{Workspace.FullName}'!");
+                throw new Exception($"No compatible environment found in workspace '{Workspace.FullName}'!");
             }
 
             return env;

--- a/source/modules/Packsly3.Core/Packsly3.Core.csproj
+++ b/source/modules/Packsly3.Core/Packsly3.Core.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <Compile Include="Common\Json\LowercaseContractResolver.cs" />
     <Compile Include="Common\Json\RelativePathConverter.cs" />
+    <Compile Include="FileSystem\PackslyConfig.cs" />
     <Compile Include="FileSystem\PackslyInstanceFile.cs" />
     <Compile Include="Launcher\Adapter\AdapterHandler.cs" />
     <Compile Include="Launcher\Adapter\IAdapter.cs" />


### PR DESCRIPTION
### Summary
Introduces a new 'packsly.json' file that holds configuration for the program.
This PR aims to resolve feature described in #4.

At this point of time, the config file is used to specify default program workspace (absolute and relative paths are supported) and default mod-pack source (local files and absolute uris are supported).

The configuration file is created automatically, with default values when Packsly starts. 
