### PR TITLE
Support for environment specific resources

### DIFF
--- a/resources/modpack-definition-example.json
+++ b/resources/modpack-definition-example.json
@@ -47,7 +47,15 @@
 					"filename": "foresters-manual.zs"
 				}
 			]
-		}
+		},
+		{
+			"url": "https://minecraft.curseforge.com/projects/journeymap/files/2498312/download",
+			"filename": "journeymap-1.12.2-5.5.2.jar",
+			"environment": {
+				"on": [ "server" ],
+				"isBlacklist": true
+			}
+		},
 	]
 }
 

--- a/source/modules/Packsly3.Cli/Program.cs
+++ b/source/modules/Packsly3.Cli/Program.cs
@@ -55,13 +55,13 @@ namespace Packsly3.Cli {
             Console.WriteLine();
 
             if (PackslyConfig.Instnace.Workspace != null && PackslyConfig.Instnace.Workspace.Exists) {
-                Launcher.Workspace = PackslyConfig.Instnace.Workspace;
-                Console.WriteLine($"Workspace was set from configuration file to: {Launcher.Workspace}");
+                MinecraftLauncher.Workspace = PackslyConfig.Instnace.Workspace;
+                Console.WriteLine($"Workspace was set from configuration file to: {MinecraftLauncher.Workspace}");
                 Console.WriteLine();
             }
 
             Console.WriteLine("Detecting environment...");
-            Console.WriteLine($" > Current handler: {Launcher.Current}");
+            Console.WriteLine($" > CurrentEnvironment handler: {MinecraftLauncher.CurrentEnvironment}");
             Console.WriteLine();
 
             string modpackSource = PackslyConfig.Instnace.DefaultModpackSource;

--- a/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
+++ b/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
@@ -82,7 +82,7 @@ namespace Packsly3.Core.Launcher.Adapter.Impl {
 
         private static void UpdateMods(IMinecraftInstance instance, ModpackDefinition modpack) {
             foreach (FileInfo modFile in instance.Files.GetGroup(FileManager.GroupType.Mod)) {
-                if (modpack.Mods.Any(mm => mm.FileName == modFile.Name)) {
+                if (modpack.Mods.Any(mm => mm.FileName == modFile.Name && mm.ShouldDownload)) {
                     continue;
                 }
 
@@ -93,7 +93,7 @@ namespace Packsly3.Core.Launcher.Adapter.Impl {
 
             RemoteResource[] modResourceBlob = modpack.Mods.SelectMany(m => m.Resources).ToArray();
             foreach (FileInfo modResourceFile in instance.Files.GetGroup(FileManager.GroupType.ModResource)) {
-                if (modResourceBlob.Any(mr => mr.FileName == modResourceFile.Name)) {
+                if (modResourceBlob.Any(mr => mr.FileName == modResourceFile.Name && mr.ShouldDownload)) {
                     continue;
                 }
 
@@ -102,13 +102,13 @@ namespace Packsly3.Core.Launcher.Adapter.Impl {
                 modResourceFile.Delete();
             }
 
-            foreach (ModSource modpackMod in modpack.Mods) {
+            foreach (ModSource modpackMod in modpack.Mods.Where(mod => mod.ShouldDownload)) {
                 if (!instance.Files.DoesGroupContain(FileManager.GroupType.Mod, modpackMod)) {
                     Console.WriteLine($" > Downloading mod {modpackMod.FileName}...");
                     instance.Files.Download(modpackMod, FileManager.GroupType.Mod);
                 }
 
-                foreach (RemoteResource modpackModResource in modpackMod.Resources) {
+                foreach (RemoteResource modpackModResource in modpackMod.Resources.Where(resource => resource.ShouldDownload)) {
                     Console.WriteLine($" > Downloading mod resource {modpackModResource.FileName}...");
                     instance.Files.Download(modpackModResource, FileManager.GroupType.ModResource);
                 }

--- a/source/modules/Packsly3.Core/Launcher/Instance/Lifecycle.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/Lifecycle.cs
@@ -31,7 +31,7 @@ namespace Packsly3.Core.Launcher.Instance {
 
         public static class Dispatcher {
 
-            public static EventHandler<Changed> LifecycleEvent;
+            public static readonly EventHandler<Changed> LifecycleEvent;
 
             static Dispatcher() {
                 LifecycleEvent += AdapterHandler.OnLifecycleChanged;

--- a/source/modules/Packsly3.Core/Launcher/Instance/MinecraftInstanceFactory.cs
+++ b/source/modules/Packsly3.Core/Launcher/Instance/MinecraftInstanceFactory.cs
@@ -44,13 +44,23 @@ namespace Packsly3.Core.Launcher.Instance {
 
             // Download mods
             foreach (ModSource mod in modpackDefinition.Mods) {
-                Console.WriteLine($"Downloading mod '{mod.FileName}' to '{mod.FilePath}'...");
-                instance.Files.Download(mod, FileManager.GroupType.Mod);
+                if (mod.ShouldDownload) {
+                    Console.WriteLine($"Downloading mod '{mod.FileName}' to '{mod.FilePath}'...");
+                    instance.Files.Download(mod, FileManager.GroupType.Mod);
+                }
+                else {
+                    Console.WriteLine($"Skipping downloading of mod '{mod.FileName}' since it is {(mod.EnvironmentOnly.IsBlacklist ? "blacklisted" : "whitelisted")} in '{string.Join(", ", mod.EnvironmentOnly.Entries)}'...");
+                }
 
                 // Download mod resources
                 foreach (RemoteResource resource in mod.Resources) {
-                    Console.WriteLine($" > Downloading resource '{resource.FileName}' to '{resource.FilePath}'...");
-                    instance.Files.Download(resource, FileManager.GroupType.ModResource);
+                    if (resource.ShouldDownload) {
+                        Console.WriteLine($" > Downloading resource '{resource.FileName}' to '{resource.FilePath}'...");
+                        instance.Files.Download(resource, FileManager.GroupType.ModResource);
+                    }
+                    else {
+                        Console.WriteLine($" > Skipping downloading of resource '{mod.FileName}' since it is {(mod.EnvironmentOnly.IsBlacklist ? "blacklisted" : "whitelisted")} in '{string.Join(", ", mod.EnvironmentOnly.Entries)}'...");
+                    }
                 }
             }
             instance.Files.Save();
@@ -61,7 +71,7 @@ namespace Packsly3.Core.Launcher.Instance {
         }
 
         private static IMinecraftInstance CreateMinecraftInstnace(string instanceId, ModpackDefinition modpackDefinition) {
-            IMinecraftInstance instance = Launcher.CreateInstance(instanceId);
+            IMinecraftInstance instance = MinecraftLauncher.CreateInstance(instanceId);
 
             // Set base minecraft instance properties
             instance.Name = modpackDefinition.Name;
@@ -80,7 +90,7 @@ namespace Packsly3.Core.Launcher.Instance {
             // Configure instance using compatible enviroment settings
             foreach (KeyValuePair<string, object> environmentEntry in modpackDefinition.Environments) {
                 string name = environmentEntry.Key;
-                if (name != Launcher.Current.Name)
+                if (name != MinecraftLauncher.CurrentEnvironment.Name)
                     continue;
 
                 string settings = environmentEntry.Value.ToString();

--- a/source/modules/Packsly3.Core/Launcher/MinecraftLauncher.cs
+++ b/source/modules/Packsly3.Core/Launcher/MinecraftLauncher.cs
@@ -8,7 +8,7 @@ using Packsly3.Core.Launcher.Instance;
 
 namespace Packsly3.Core.Launcher {
 
-    public static class Launcher {
+    public static class MinecraftLauncher {
 
         private static readonly ILauncherEnvironment[] Enviroments =
             RegisterAttribute.GetOccurrencesFor<ILauncherEnvironment>();
@@ -17,7 +17,7 @@ namespace Packsly3.Core.Launcher {
 
         public static DirectoryInfo Workspace { get; set; } = Root;
 
-        public static ILauncherEnvironment Current
+        public static ILauncherEnvironment CurrentEnvironment
             => _currentEnviroment ?? (_currentEnviroment = GetCurrentEnvironment());
 
         private static ILauncherEnvironment _currentEnviroment;
@@ -36,13 +36,13 @@ namespace Packsly3.Core.Launcher {
         }
 
         public static IMinecraftInstance[] GetInstances()
-            => Current.GetInstances(Workspace).ToArray();
+            => CurrentEnvironment.GetInstances(Workspace).ToArray();
 
         public static IMinecraftInstance GetInstance(string id)
-            => Current.GetInstance(Workspace, id);
+            => CurrentEnvironment.GetInstance(Workspace, id);
 
         public static IMinecraftInstance CreateInstance(string id)
-            => Current.CreateInstance(Workspace, id);
+            => CurrentEnvironment.CreateInstance(Workspace, id);
     }
 
 }

--- a/source/modules/Packsly3.Core/Modpack/EnvironmentSpecific.cs
+++ b/source/modules/Packsly3.Core/Modpack/EnvironmentSpecific.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace Packsly3.Core.Modpack {
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class EnvironmentSpecific {
+
+        [JsonProperty("on")]
+        public string[] Entries { private set; get; } = new string[0];
+
+        public bool IsEnvironmentSpecific
+            => Entries.Length > 0;
+
+        [JsonProperty("isBlacklist", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public bool IsBlacklist { private set; get; }
+
+        public bool IsWhitelist
+            => !IsBlacklist;
+
+    }
+
+}

--- a/source/modules/Packsly3.Core/Modpack/RemoteResource.cs
+++ b/source/modules/Packsly3.Core/Modpack/RemoteResource.cs
@@ -1,16 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Packsly3.Core.Launcher;
 using Packsly3.Core.Launcher.Instance;
 
 namespace Packsly3.Core.Modpack {
 
+    [JsonObject(MemberSerialization.OptIn)]
     public class RemoteResource {
 
         [JsonProperty("url")]
@@ -21,6 +19,22 @@ namespace Packsly3.Core.Modpack {
 
         [JsonProperty("filename")]
         public string FileName { protected set; get; }
+
+        [JsonProperty("environment", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public EnvironmentSpecific EnvironmentOnly { private set; get; } = new EnvironmentSpecific();
+
+        public bool ShouldDownload {
+            get {
+                if (!EnvironmentOnly.IsEnvironmentSpecific)
+                    return true;
+
+                bool containsEntry = EnvironmentOnly.Entries.Any(entry => entry == MinecraftLauncher.CurrentEnvironment.Name);
+                if (EnvironmentOnly.IsWhitelist && !containsEntry)
+                    return false;
+
+                return !EnvironmentOnly.IsBlacklist || !containsEntry;
+            }
+        }
 
         [OnDeserialized]
         private void OnDeserialized(StreamingContext context) {

--- a/source/modules/Packsly3.Core/Packsly3.Core.csproj
+++ b/source/modules/Packsly3.Core/Packsly3.Core.csproj
@@ -54,12 +54,13 @@
     <Compile Include="Launcher\Instance\Lifecycle.cs" />
     <Compile Include="Launcher\Instance\EnvironmentVariables.cs" />
     <Compile Include="Launcher\Instance\Icon.cs" />
+    <Compile Include="Modpack\EnvironmentSpecific.cs" />
     <Compile Include="Modpack\ModSource.cs" />
     <Compile Include="Modpack\RemoteResource.cs" />
     <Compile Include="Modpack\ModpackDefinition.cs" />
     <Compile Include="Launcher\Instance\MinecraftInstanceFactory.cs" />
     <Compile Include="Common\PackslyAssemblyLoader.cs" />
-    <Compile Include="Launcher\Launcher.cs" />
+    <Compile Include="Launcher\MinecraftLauncher.cs" />
     <Compile Include="Launcher\ILauncherEnvironment.cs" />
     <Compile Include="Launcher\Instance\IMinecraftInstance.cs" />
     <Compile Include="Launcher\Modloader\IModLoaderHandler.cs" />

--- a/source/modules/Packsly3.MultiMC/Launcher/MmcMinecraftInstance.cs
+++ b/source/modules/Packsly3.MultiMC/Launcher/MmcMinecraftInstance.cs
@@ -69,7 +69,7 @@ namespace Packsly3.MultiMC.Launcher {
             PackFile = new MmcPackFile(Location.FullName);
             PackFile.Load();
 
-            Icon = new Icon(Path.Combine(Core.Launcher.Launcher.Workspace.FullName, "icons"), MmcConfig.IconName);
+            Icon = new Icon(Path.Combine(Core.Launcher.MinecraftLauncher.Workspace.FullName, "icons"), MmcConfig.IconName);
             Icon.IconChanged += (sender, args)
                 => MmcConfig.IconName = (sender as Icon)?.Source;
 


### PR DESCRIPTION
### Summary
This PR resolves #9 feature draft.

Since there are mods that can be only present on the server (like morpheus that adds sleep voting) or on client (like a mini-map), this PR aims to implement this functionality by allowing environment specific settings for remote resources in mod-pack definition.

### Functionality
Remote resources can now have optional `environment` property that can be used to specify a list of environment names and flag to determinate if given list is whitelist or a blacklist.

### Format example
An example of a mini-map mod, that will not be downloaded or updated on the server:
```json
{
	"url": "https://minecraft.curseforge.com/projects/journeymap/files/2498312/download",
	"filename": "journeymap-1.12.2-5.5.2.jar",
	"environment": {
		"on": [ "server" ],
		"isBlacklist": true
	}
}
```
