### PR TITLE
Fixed revision update adapter not updating it's config

### DIFF
--- a/source/modules/Packsly3.Core/Launcher/Adapter/AdapterHandler.cs
+++ b/source/modules/Packsly3.Core/Launcher/Adapter/AdapterHandler.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using Packsly3.Core.Common;
 using Packsly3.Core.Launcher.Instance;
-using Packsly3.Core.Launcher.Modloader;
 
 namespace Packsly3.Core.Launcher.Adapter {
 
-    public static class AdapterHandler {
+    internal static class AdapterHandler {
 
-        public static readonly IAdapter[] Adapters = RegisterAttribute.GetOccurrencesFor<IAdapter>();
+        internal static readonly IAdapter[] Adapters = RegisterAttribute.GetOccurrencesFor<IAdapter>();
 
-        public static void OnLifecycleChanged(object sender, Lifecycle.Changed args) {
+        internal static void OnLifecycleChanged(object sender, Lifecycle.Changed args) {
             IEnumerable<IAdapter> usedAdapters = Adapters
                 .Where(adapter => args.Instance.PackslyConfig.Adapters.Contains(adapter.Id))
                 .Where(adapter => adapter.IsCompatible(args.Instance))

--- a/source/modules/Packsly3.Core/Launcher/Adapter/IAdapter.cs
+++ b/source/modules/Packsly3.Core/Launcher/Adapter/IAdapter.cs
@@ -1,9 +1,10 @@
 ﻿using Newtonsoft.Json.Linq;
+using Packsly3.Core.FileSystem;
 using Packsly3.Core.Launcher.Instance;
 
 namespace Packsly3.Core.Launcher.Adapter {
 
-    public interface IAdapter {
+    internal interface IAdapter {
 
         string Id { get; }
 
@@ -12,6 +13,8 @@ namespace Packsly3.Core.Launcher.Adapter {
         bool IsCompatible(string lifecycleEvent);
 
         void Execute(JObject config, string lifecycleEvent, IMinecraftInstance instance);
+
+        void Save(IMinecraftInstance instance, object config);
 
     }
 
@@ -31,6 +34,12 @@ namespace Packsly3.Core.Launcher.Adapter {
         #endregion
 
         public abstract void Execute(T config, string lifecycleEvent, IMinecraftInstance instance);
+
+        public void Save(IMinecraftInstance instance, object config) {
+            PackslyInstanceFile cfg = instance.PackslyConfig;
+            cfg.Adapters.SetConfigFor(this, config);
+            cfg.Save();
+        }
 
     }
 

--- a/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
+++ b/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
@@ -47,7 +47,7 @@ namespace Packsly3.Core.Launcher.Adapter.Impl {
                 RevisionUpdateSchemaConfig remoteConfig =
                     JObject.FromObject(remoteModpack.Adapters[Id]).ToObject<RevisionUpdateSchemaConfig>();
 
-                // If there is a upate available
+                // If there is an update available
                 if (config.Revision != remoteConfig.Revision) {
                     Console.WriteLine($" > Updating modpack from revision {config.Revision} to {remoteConfig.Revision}!");
 


### PR DESCRIPTION
### Summary
This PR closes #11 issue.

Fixes a problem where `RevisionUpdateAdapter` would not update it's  adapter config after performing an update. This resulted in mod-pack having outdated revision number, triggering updates every time, even when mod-pack was already up to date.

### Included changes

- Fix for #11 issue
- Adapter config updating is now possible for adapters outside of the core
- `AdapterHandler` and `IAdapter` are now internal, there is no reason to use them outside of the core