### PR TITLE
FileManager removes references to tracked non-existing files

### DIFF
--- a/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
+++ b/source/modules/Packsly3.Core/Launcher/Adapter/Impl/RevisionUpdateAdapter.cs
@@ -103,7 +103,7 @@ namespace Packsly3.Core.Launcher.Adapter.Impl {
             }
 
             foreach (ModSource modpackMod in modpack.Mods.Where(mod => mod.ShouldDownload)) {
-                if (!instance.Files.DoesGroupContain(FileManager.GroupType.Mod, modpackMod)) {
+                if (!instance.Files.GroupContains(FileManager.GroupType.Mod, modpackMod)) {
                     Console.WriteLine($" > Downloading mod {modpackMod.FileName}...");
                     instance.Files.Download(modpackMod, FileManager.GroupType.Mod);
                 }


### PR DESCRIPTION
### Summary
This PR closes #14 cleanup draft.

There is no need for `FileManager` to keep track of files that were removed or are missing.
This PR makes checks for non-existing files when constructing `FileManager` and removes them from the tracking list.

### Included changes
- Implementation of #14 cleanup draft
- Region grouping and renaming of `FileManager` methods to be more consistent